### PR TITLE
Update proxy name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] (Unreleased)
+
+### Changed
+
+- Updated proxy configuration so that we use the term `portal` instead of `ui`. [#56](https://github.com/unity-sds/unity-portal/issues/56)
+
 ## [0.2.0] 2025-01-14
 
 ### Added 

--- a/terraform-unity-ui/ecs.tf
+++ b/terraform-unity-ui/ecs.tf
@@ -41,11 +41,11 @@ resource "aws_ecs_task_definition" "app" {
           },
           {
             name = "ENV_UNITY_UI_BASE_PATH"
-            value = "/${var.project}/${var.venue}/ui"
+            value = "/${var.project}/${var.venue}/portal"
           },
           {
             name = "ENV_UNITY_UI_AUTH_OAUTH_REDIRECT_URI"
-            value = "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/ui"
+            value = "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/portal"
           },
           {
             name = "ENV_UNITY_UI_AUTH_OAUTH_LOGOUT_ENDPOINT"

--- a/terraform-unity-ui/proxy.tf
+++ b/terraform-unity-ui/proxy.tf
@@ -4,7 +4,7 @@ resource "aws_ssm_parameter" "uiux_ui_proxy_config" {
   type       = "String"
   value      = <<-EOT
 
-    <location "/${var.project}/${var.venue}/ui">
+    <location "/${var.project}/${var.venue}/portal">
       ProxyHTMLEnable on
       RequestHeader unset Accept-Encoding
       ProxyHTMLCHarsetOut *
@@ -13,7 +13,7 @@ resource "aws_ssm_parameter" "uiux_ui_proxy_config" {
       Header always set Strict-Transport-Security "max-age=63072000"
       ProxyPass "http://${aws_lb.main.dns_name}:8080/" retry=5 disablereuse=On
       ProxyPassReverse "http://${aws_lb.main.dns_name}:8080/"
-      ProxyHTMLURLMap / /${var.project}/${var.venue}/ui/
+      ProxyHTMLURLMap / /${var.project}/${var.venue}/portal/
     </location>
 
 EOT

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -6,7 +6,7 @@ variable "app_count" {
 
 variable "app_image" {
   description = "The docker image to run the application."
-  default = "ghcr.io/unity-sds/unity-ui/unity-ui-application:latest"
+  default = "ghcr.io/unity-sds/unity-ui/unity-portal-application:latest"
   type = string
 }
 

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -6,7 +6,7 @@ variable "app_count" {
 
 variable "app_image" {
   description = "The docker image to run the application."
-  default = "ghcr.io/unity-sds/unity-ui/unity-portal-application:latest"
+  default = "ghcr.io/unity-sds/unity-ui/unity-portal-application:0.9.0-unstable"
   type = string
 }
 

--- a/terraform-unity-ui/variables.tf
+++ b/terraform-unity-ui/variables.tf
@@ -39,7 +39,7 @@ variable "additional_tags" {
   type        = map(string)
   default     = {
     ServiceArea = "uiux"
-    CapVersion = "0.8.0"
+    CapVersion = "0.9.0"
     Component = "navbar"
     CreatedBy = "uiux"
     Env = "dev"


### PR DESCRIPTION
## Purpose

This PR addresses our rebranding updates.

## Proposed Changes
- [CHANGE] Proxy configuration to use the term `portal` instead of `ui`
- [CHANGE] Updated docker image reference for portal application.

## Issues

Resolves https://github.com/unity-sds/unity-portal/issues/56